### PR TITLE
Add new membership signup polling trigger (before confirmation)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import ActivityCreate from "./creates/activity";
 import triggerBookingCreated from "./triggers/triggerBookingCreated";
 import triggerBookingWillBegin from "./triggers/triggerBookingWillBegin";
 import triggerMembershipConfirmed from "./triggers/triggerMembershipConfirmed";
+import triggerMembershipCreated from "./triggers/triggerMembershipCreated";
 import triggerMembershipPlanChanged from "./triggers/triggerMembershipPlanChanged";
 import triggerExternalBookingCreated from "./triggers/triggerExternalBookingCreated";
 import getSubdomains from "./triggers/dropdowns/getSubdomains";
@@ -43,6 +44,7 @@ export default {
     [triggerBookingCreated.key]: triggerBookingCreated,
     [triggerBookingWillBegin.key]: triggerBookingWillBegin,
     [triggerMembershipConfirmed.key]: triggerMembershipConfirmed,
+    [triggerMembershipCreated.key]: triggerMembershipCreated,
     [triggerMembershipCancelled.key]: triggerMembershipCancelled,
     [triggerMembershipPlanChanged.key]: triggerMembershipPlanChanged,
     [triggerEventPublished.key]: triggerEventPublished,

--- a/src/triggers/triggerMembershipCreated.ts
+++ b/src/triggers/triggerMembershipCreated.ts
@@ -1,0 +1,59 @@
+import { ZObject } from "zapier-platform-core";
+import { KontentBundle } from "../types/kontentBundle";
+import { SubscribeBundleInputType } from "../types/subscribeType";
+import { getSubdomainField } from "../fields/getSudomainsField";
+import { MembershipOutput } from "../types/outputs";
+import { apiResponseToMembershipOutput } from "../utils/api-to-output";
+import { membershipSample } from "../utils/samples";
+
+const triggerLabel = "New Membership Signup";
+
+async function performPolling(
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+): Promise<MembershipOutput[]> {
+  const url = `https://${bundle.inputData.subdomain}.cobot.me/api/memberships?all=true`;
+  const response = await z.request({
+    url,
+    method: "GET",
+  });
+  const memberships = response.data;
+
+  // Return only unconfirmed memberships (new signups not yet confirmed)
+  const unconfirmedMemberships = memberships.filter(
+    (m: any) => m.confirmed_at === null,
+  );
+
+  return Promise.all(
+    unconfirmedMemberships.map((m: any) =>
+      apiResponseToMembershipOutput(m, z),
+    ),
+  );
+}
+
+const trigger = {
+  key: "membership_created",
+  noun: triggerLabel,
+  display: {
+    label: triggerLabel,
+    description:
+      "Triggers when a new membership is created (before confirmation).",
+  },
+  operation: {
+    type: "polling" as const,
+    inputFields: [getSubdomainField()],
+    perform: performPolling,
+    sample: membershipSample,
+    outputFields: [
+      { key: "id", label: "Membership ID" },
+      { key: "name", label: "Name" },
+      { key: "email", label: "Email" },
+      { key: "phone", label: "Phone" },
+      { key: "company", label: "Company" },
+      { key: "plan_name", label: "Plan Name" },
+      { key: "confirmed_at", label: "Confirmed At" },
+    ],
+  },
+};
+
+export default trigger;


### PR DESCRIPTION
Adds a new polling trigger that fires when a membership is created 
but not yet confirmed. This allows spaces to automate workflows 
for new signups before the admin confirmation step.

The trigger uses the existing /api/memberships?all=true endpoint 
and filters for memberships where confirmed_at is null. Zapier's 
built-in deduplication (based on membership id) ensures each 
signup only triggers once.

Uses the same MembershipOutput format and apiResponseToMembershipOutput 
utility as the existing confirmed_membership trigger.