### PR TITLE
Add created, updated, and deleted resource webhook triggers

### DIFF
--- a/src/fields/field.ts
+++ b/src/fields/field.ts
@@ -7,7 +7,8 @@ export type Field = Readonly<{
     | "copy"
     | "text"
     | "unicode"
-    | "float";
+    | "float"
+    | "boolean";
   label: string;
   dynamic?: string;
   list?: boolean;
@@ -17,6 +18,6 @@ export type Field = Readonly<{
   choices?: ReadonlyArray<
     Readonly<{ value: string; sample: string; label: string }>
   >;
-  default?: string;
+  default?: string | boolean;
   search?: string;
 }>;

--- a/src/fields/field.ts
+++ b/src/fields/field.ts
@@ -7,8 +7,7 @@ export type Field = Readonly<{
     | "copy"
     | "text"
     | "unicode"
-    | "float"
-    | "boolean";
+    | "float";
   label: string;
   dynamic?: string;
   list?: boolean;
@@ -18,6 +17,6 @@ export type Field = Readonly<{
   choices?: ReadonlyArray<
     Readonly<{ value: string; sample: string; label: string }>
   >;
-  default?: string | boolean;
+  default?: string;
   search?: string;
 }>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,9 @@ import triggerMembershipUpdated, {
   deprecatedUpdatedMembership,
 } from "./triggers/triggerMembershipUpdated";
 import triggerMembershipPlanChangedEvent from "./triggers/triggerMembershipPlanChangedEvent";
+import triggerResourceCreated from "./triggers/triggerResourceCreated";
+import triggerResourceUpdated from "./triggers/triggerResourceUpdated";
+import triggerResourceDeleted from "./triggers/triggerResourceDeleted";
 
 const { version } = require("../package.json");
 
@@ -65,6 +68,9 @@ export default {
     [triggerMembershipUpdated.key]: triggerMembershipUpdated,
     [deprecatedUpdatedMembership.key]: deprecatedUpdatedMembership,
     [triggerMembershipPlanChangedEvent.key]: triggerMembershipPlanChangedEvent,
+    [triggerResourceCreated.key]: triggerResourceCreated,
+    [triggerResourceUpdated.key]: triggerResourceUpdated,
+    [triggerResourceDeleted.key]: triggerResourceDeleted,
     // Lists for dropdowns
     [getSubdomains.key]: getSubdomains,
   },

--- a/src/test/triggers/triggerResourceCreated.test.ts
+++ b/src/test/triggers/triggerResourceCreated.test.ts
@@ -96,7 +96,7 @@ describe("triggerResourceCreated", () => {
     const bundle = prepareBundle();
     bundle.inputData = {
       ...bundle.inputData,
-      trigger_for_existing: true,
+      trigger_for_existing: "Yes",
     };
     const url = `https://${bundle.inputData.subdomain}.cobot.me/api/subscriptions`;
     nock(url)

--- a/src/test/triggers/triggerResourceCreated.test.ts
+++ b/src/test/triggers/triggerResourceCreated.test.ts
@@ -104,6 +104,32 @@ describe("triggerResourceCreated", () => {
 `);
   });
 
+  it("sends notify_existing when Trigger for existing is enabled", async () => {
+    const bundle = prepareBundle();
+    bundle.inputData = {
+      ...bundle.inputData,
+      trigger_for_existing: true,
+    };
+    const url = `https://${bundle.inputData.subdomain}.cobot.me/api/subscriptions`;
+    nock(url)
+      .post("", {
+        event: triggerResourceCreated.key,
+        callback_url: bundle.targetUrl,
+        notify_existing: true,
+      })
+      .reply(200, { url: "https://trial.cobot.me/api/event/callback" });
+
+    const result = await appTester(
+      trigger.operation.performSubscribe as any,
+      bundle as any,
+    );
+
+    expect(nock.isDone()).toBe(true);
+    expect(result).toEqual({
+      url: "https://trial.cobot.me/api/event/callback",
+    });
+  });
+
   it("lists resources", async () => {
     const bundle = prepareBundle();
     const userResponse: UserApiResponse = {

--- a/src/test/triggers/triggerResourceCreated.test.ts
+++ b/src/test/triggers/triggerResourceCreated.test.ts
@@ -31,15 +31,6 @@ const resourceResponse: ResourceApiResponse = {
     hidden: false,
     color: "#ff0000",
     accountingCode: "ROOM",
-    pricing: {
-      currency: "EUR",
-      pricePerHour: {
-        net: "10.0",
-        gross: "12.0",
-        currency: "EUR",
-        taxes: [{ name: "Tax", rate: "20.0", amount: "2.0" }],
-      },
-    },
     photo: {
       icon: {
         url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/icon_photo.png",
@@ -81,9 +72,6 @@ const resourceOutput: ResourceOutput = {
   hidden: false,
   color: "#ff0000",
   accountingCode: "ROOM",
-  pricePerHourNet: "10.0",
-  pricePerHourGross: "12.0",
-  currency: "EUR",
   photoUrl:
     "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
 };

--- a/src/test/triggers/triggerResourceCreated.test.ts
+++ b/src/test/triggers/triggerResourceCreated.test.ts
@@ -1,0 +1,146 @@
+import { createAppTester } from "zapier-platform-core";
+import * as nock from "nock";
+import App from "../../index";
+import {
+  prepareBundle,
+  prepareMocksForWebhookSubscribeTest,
+} from "../utils/prepareMocksForWebhookSubscribeTest";
+import triggerResourceCreated from "../../triggers/triggerResourceCreated";
+import { HookTrigger } from "../../types/trigger";
+import {
+  UserApiResponse,
+  ResourceApiResponse,
+} from "../../types/api-responses";
+import { ResourceOutput } from "../../types/outputs";
+
+const appTester = createAppTester(App);
+nock.disableNetConnect();
+const trigger = App.triggers[triggerResourceCreated.key] as HookTrigger;
+
+afterEach(() => nock.cleanAll());
+
+const resourceResponse: ResourceApiResponse = {
+  id: "a4a99a71ac8df98d29de357180d273d3",
+  attributes: {
+    name: "Meeting Room",
+    resourceType: "room",
+    usage: "bookable",
+    description: "Large room, fits 12.",
+    capacity: 12,
+    units: 2,
+    hidden: false,
+    color: "#ff0000",
+    accountingCode: "ROOM",
+    pricing: {
+      currency: "EUR",
+      pricePerHour: {
+        net: "10.0",
+        gross: "12.0",
+        currency: "EUR",
+        taxes: [{ name: "Tax", rate: "20.0", amount: "2.0" }],
+      },
+    },
+    photo: {
+      icon: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/icon_photo.png",
+        width: 120,
+        height: 120,
+      },
+      default: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
+        width: 800,
+        height: 600,
+      },
+      small: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/small_photo.png",
+        width: 200,
+        height: 150,
+      },
+      medium: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/medium_photo.png",
+        width: 400,
+        height: 300,
+      },
+      large: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/large_photo.png",
+        width: 1200,
+        height: 900,
+      },
+    },
+  },
+};
+
+const resourceOutput: ResourceOutput = {
+  id: "a4a99a71ac8df98d29de357180d273d3",
+  name: "Meeting Room",
+  resourceType: "room",
+  usage: "bookable",
+  description: "Large room, fits 12.",
+  capacity: 12,
+  units: 2,
+  hidden: false,
+  color: "#ff0000",
+  accountingCode: "ROOM",
+  pricePerHourNet: "10.0",
+  pricePerHourGross: "12.0",
+  currency: "EUR",
+  photoUrl:
+    "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
+};
+
+describe("triggerResourceCreated", () => {
+  it("creates new webhook through CM API upon subscribe", async () => {
+    const bundle = prepareMocksForWebhookSubscribeTest(
+      triggerResourceCreated.key,
+    );
+    const subscribe = trigger.operation.performSubscribe;
+
+    const result = await appTester(subscribe as any, bundle as any);
+
+    expect(result).toMatchInlineSnapshot(`
+{
+  "url": "https://trial.cobot.me/api/event/callback",
+}
+`);
+  });
+
+  it("lists resources", async () => {
+    const bundle = prepareBundle();
+    const userResponse: UserApiResponse = {
+      included: [{ id: "space-1", attributes: { subdomain: "trial" } }],
+    };
+
+    const scope = nock("https://api.cobot.me");
+    scope.get("/user?include=adminOf").reply(200, userResponse);
+    scope
+      .get("/spaces/space-1/resources")
+      .query({ "filter[usage]": "all" })
+      .reply(200, { data: [resourceResponse] });
+
+    const results = await appTester(
+      trigger.operation.performList as any,
+      bundle as any,
+    );
+
+    expect(nock.isDone()).toBe(true);
+    expect(results).toStrictEqual([resourceOutput]);
+  });
+
+  it("triggers on resource created", async () => {
+    const bundle = prepareBundle({
+      url: "https://api.cobot.me/resources/a4a99a71ac8df98d29de357180d273d3",
+    });
+    const scope = nock("https://api.cobot.me");
+    scope
+      .get("/resources/a4a99a71ac8df98d29de357180d273d3")
+      .reply(200, { data: resourceResponse });
+
+    const results = await appTester(
+      trigger.operation.perform as any,
+      bundle as any,
+    );
+
+    expect(nock.isDone()).toBe(true);
+    expect(results).toStrictEqual([resourceOutput]);
+  });
+});

--- a/src/test/triggers/triggerResourceDeleted.test.ts
+++ b/src/test/triggers/triggerResourceDeleted.test.ts
@@ -1,0 +1,78 @@
+import { createAppTester } from "zapier-platform-core";
+import * as nock from "nock";
+import App from "../../index";
+import {
+  prepareBundle,
+  prepareMocksForWebhookSubscribeTest,
+} from "../utils/prepareMocksForWebhookSubscribeTest";
+import triggerResourceDeleted from "../../triggers/triggerResourceDeleted";
+import { HookTrigger } from "../../types/trigger";
+import {
+  UserApiResponse,
+  ResourceApiResponse,
+} from "../../types/api-responses";
+
+const appTester = createAppTester(App);
+nock.disableNetConnect();
+const trigger = App.triggers[triggerResourceDeleted.key] as HookTrigger;
+
+afterEach(() => nock.cleanAll());
+
+const resourceResponse: ResourceApiResponse = {
+  id: "a4a99a71ac8df98d29de357180d273d3",
+  attributes: {
+    name: "Meeting Room",
+  },
+};
+
+describe("triggerResourceDeleted", () => {
+  it("creates new webhook through CM API upon subscribe", async () => {
+    const bundle = prepareMocksForWebhookSubscribeTest(
+      triggerResourceDeleted.key,
+    );
+    const subscribe = trigger.operation.performSubscribe;
+
+    const result = await appTester(subscribe as any, bundle as any);
+
+    expect(result).toMatchInlineSnapshot(`
+{
+  "url": "https://trial.cobot.me/api/event/callback",
+}
+`);
+  });
+
+  it("lists resource ids", async () => {
+    const bundle = prepareBundle();
+    const userResponse: UserApiResponse = {
+      included: [{ id: "space-1", attributes: { subdomain: "trial" } }],
+    };
+
+    const scope = nock("https://api.cobot.me");
+    scope.get("/user?include=adminOf").reply(200, userResponse);
+    scope
+      .get("/spaces/space-1/resources")
+      .query({ "filter[usage]": "all" })
+      .reply(200, { data: [resourceResponse] });
+
+    const results = await appTester(
+      trigger.operation.performList as any,
+      bundle as any,
+    );
+
+    expect(nock.isDone()).toBe(true);
+    expect(results).toStrictEqual([{ id: "a4a99a71ac8df98d29de357180d273d3" }]);
+  });
+
+  it("triggers on resource deleted with id from url only", async () => {
+    const bundle = prepareBundle({
+      url: "https://api.cobot.me/resources/a4a99a71ac8df98d29de357180d273d3",
+    });
+
+    const results = await appTester(
+      trigger.operation.perform as any,
+      bundle as any,
+    );
+
+    expect(results).toStrictEqual([{ id: "a4a99a71ac8df98d29de357180d273d3" }]);
+  });
+});

--- a/src/test/triggers/triggerResourceUpdated.test.ts
+++ b/src/test/triggers/triggerResourceUpdated.test.ts
@@ -1,0 +1,146 @@
+import { createAppTester } from "zapier-platform-core";
+import * as nock from "nock";
+import App from "../../index";
+import {
+  prepareBundle,
+  prepareMocksForWebhookSubscribeTest,
+} from "../utils/prepareMocksForWebhookSubscribeTest";
+import triggerResourceUpdated from "../../triggers/triggerResourceUpdated";
+import { HookTrigger } from "../../types/trigger";
+import {
+  UserApiResponse,
+  ResourceApiResponse,
+} from "../../types/api-responses";
+import { ResourceOutput } from "../../types/outputs";
+
+const appTester = createAppTester(App);
+nock.disableNetConnect();
+const trigger = App.triggers[triggerResourceUpdated.key] as HookTrigger;
+
+afterEach(() => nock.cleanAll());
+
+const resourceResponse: ResourceApiResponse = {
+  id: "a4a99a71ac8df98d29de357180d273d3",
+  attributes: {
+    name: "Meeting Room",
+    resourceType: "room",
+    usage: "bookable",
+    description: "Large room, fits 12.",
+    capacity: 12,
+    units: 2,
+    hidden: false,
+    color: "#ff0000",
+    accountingCode: "ROOM",
+    pricing: {
+      currency: "EUR",
+      pricePerHour: {
+        net: "10.0",
+        gross: "12.0",
+        currency: "EUR",
+        taxes: [{ name: "Tax", rate: "20.0", amount: "2.0" }],
+      },
+    },
+    photo: {
+      icon: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/icon_photo.png",
+        width: 120,
+        height: 120,
+      },
+      default: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
+        width: 800,
+        height: 600,
+      },
+      small: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/small_photo.png",
+        width: 200,
+        height: 150,
+      },
+      medium: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/medium_photo.png",
+        width: 400,
+        height: 300,
+      },
+      large: {
+        url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/large_photo.png",
+        width: 1200,
+        height: 900,
+      },
+    },
+  },
+};
+
+const resourceOutput: ResourceOutput = {
+  id: "a4a99a71ac8df98d29de357180d273d3",
+  name: "Meeting Room",
+  resourceType: "room",
+  usage: "bookable",
+  description: "Large room, fits 12.",
+  capacity: 12,
+  units: 2,
+  hidden: false,
+  color: "#ff0000",
+  accountingCode: "ROOM",
+  pricePerHourNet: "10.0",
+  pricePerHourGross: "12.0",
+  currency: "EUR",
+  photoUrl:
+    "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
+};
+
+describe("triggerResourceUpdated", () => {
+  it("creates new webhook through CM API upon subscribe", async () => {
+    const bundle = prepareMocksForWebhookSubscribeTest(
+      triggerResourceUpdated.key,
+    );
+    const subscribe = trigger.operation.performSubscribe;
+
+    const result = await appTester(subscribe as any, bundle as any);
+
+    expect(result).toMatchInlineSnapshot(`
+{
+  "url": "https://trial.cobot.me/api/event/callback",
+}
+`);
+  });
+
+  it("lists resources", async () => {
+    const bundle = prepareBundle();
+    const userResponse: UserApiResponse = {
+      included: [{ id: "space-1", attributes: { subdomain: "trial" } }],
+    };
+
+    const scope = nock("https://api.cobot.me");
+    scope.get("/user?include=adminOf").reply(200, userResponse);
+    scope
+      .get("/spaces/space-1/resources")
+      .query({ "filter[usage]": "all" })
+      .reply(200, { data: [resourceResponse] });
+
+    const results = await appTester(
+      trigger.operation.performList as any,
+      bundle as any,
+    );
+
+    expect(nock.isDone()).toBe(true);
+    expect(results).toStrictEqual([resourceOutput]);
+  });
+
+  it("triggers on resource updated", async () => {
+    const bundle = prepareBundle({
+      url: "https://api.cobot.me/resources/a4a99a71ac8df98d29de357180d273d3",
+    });
+    const scope = nock("https://api.cobot.me");
+    scope
+      .get("/resources/a4a99a71ac8df98d29de357180d273d3")
+      .reply(200, { data: resourceResponse });
+
+    const results = await appTester(
+      trigger.operation.perform as any,
+      bundle as any,
+    );
+
+    expect(nock.isDone()).toBe(true);
+    expect(results).toStrictEqual([resourceOutput]);
+  });
+});

--- a/src/test/triggers/triggerResourceUpdated.test.ts
+++ b/src/test/triggers/triggerResourceUpdated.test.ts
@@ -31,15 +31,6 @@ const resourceResponse: ResourceApiResponse = {
     hidden: false,
     color: "#ff0000",
     accountingCode: "ROOM",
-    pricing: {
-      currency: "EUR",
-      pricePerHour: {
-        net: "10.0",
-        gross: "12.0",
-        currency: "EUR",
-        taxes: [{ name: "Tax", rate: "20.0", amount: "2.0" }],
-      },
-    },
     photo: {
       icon: {
         url: "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/icon_photo.png",
@@ -81,9 +72,6 @@ const resourceOutput: ResourceOutput = {
   hidden: false,
   color: "#ff0000",
   accountingCode: "ROOM",
-  pricePerHourNet: "10.0",
-  pricePerHourGross: "12.0",
-  currency: "EUR",
   photoUrl:
     "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
 };

--- a/src/triggers/triggerResourceCreated.ts
+++ b/src/triggers/triggerResourceCreated.ts
@@ -21,9 +21,13 @@ const event = "created_resource";
 const triggerForExistingField: Field = {
   label: "Trigger for existing",
   key: "trigger_for_existing",
-  type: "boolean",
+  type: "string",
   required: false,
-  default: false,
+  default: "No",
+  choices: [
+    { sample: "Yes", value: "Yes", label: "Yes" },
+    { sample: "No", value: "No", label: "No" },
+  ],
   helpText:
     "When enabled, immediately trigger for each resource that already exists in the space.",
 };
@@ -35,7 +39,9 @@ async function subscribeHookExecute(
   return subscribeHook(z, bundle, {
     event,
     callback_url: bundle.targetUrl ?? "",
-    ...(bundle.inputData.trigger_for_existing ? { notify_existing: true } : {}),
+    ...(bundle.inputData.trigger_for_existing === "Yes"
+      ? { notify_existing: true }
+      : {}),
   });
 }
 

--- a/src/triggers/triggerResourceCreated.ts
+++ b/src/triggers/triggerResourceCreated.ts
@@ -8,6 +8,7 @@ import {
 } from "../utils/api";
 import { SubscribeBundleInputType } from "../types/subscribeType";
 import { getSubdomainField } from "../fields/getSudomainsField";
+import { Field } from "../fields/field";
 import { resourceSample } from "../utils/samples";
 import { ResourceOutput } from "../types/outputs";
 import { ResourceApiResponse } from "../types/api-responses";
@@ -17,6 +18,16 @@ import { HookTrigger } from "../types/trigger";
 const hookLabel = "Resource Created";
 const event = "created_resource";
 
+const triggerForExistingField: Field = {
+  label: "Trigger for existing",
+  key: "trigger_for_existing",
+  type: "boolean",
+  required: false,
+  default: false,
+  helpText:
+    "When enabled, immediately trigger for each resource that already exists in the space.",
+};
+
 async function subscribeHookExecute(
   z: ZObject,
   bundle: KontentBundle<SubscribeBundleInputType>,
@@ -24,6 +35,7 @@ async function subscribeHookExecute(
   return subscribeHook(z, bundle, {
     event,
     callback_url: bundle.targetUrl ?? "",
+    ...(bundle.inputData.trigger_for_existing ? { notify_existing: true } : {}),
   });
 }
 
@@ -60,7 +72,7 @@ const trigger: HookTrigger = {
   operation: {
     type: "hook",
 
-    inputFields: [getSubdomainField()],
+    inputFields: [getSubdomainField(), triggerForExistingField],
 
     performSubscribe: subscribeHookExecute,
     performUnsubscribe: unsubscribeHookExecute,

--- a/src/triggers/triggerResourceCreated.ts
+++ b/src/triggers/triggerResourceCreated.ts
@@ -1,0 +1,80 @@
+import { ZObject } from "zapier-platform-core";
+import { KontentBundle } from "../types/kontentBundle";
+import {
+  apiCallUrl,
+  listResources,
+  subscribeHook,
+  unsubscribeHook,
+} from "../utils/api";
+import { SubscribeBundleInputType } from "../types/subscribeType";
+import { getSubdomainField } from "../fields/getSudomainsField";
+import { resourceSample } from "../utils/samples";
+import { ResourceOutput } from "../types/outputs";
+import { ResourceApiResponse } from "../types/api-responses";
+import { apiResponseToResourceOutput } from "../utils/api-to-output";
+import { HookTrigger } from "../types/trigger";
+
+const hookLabel = "Resource Created";
+const event = "created_resource";
+
+async function subscribeHookExecute(
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+) {
+  return subscribeHook(z, bundle, {
+    event,
+    callback_url: bundle.targetUrl ?? "",
+  });
+}
+
+async function unsubscribeHookExecute(
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+) {
+  const webhook = bundle.subscribeData;
+  return unsubscribeHook(z, bundle, webhook?.id ?? "");
+}
+
+async function parsePayload(
+  z: ZObject,
+  bundle: KontentBundle<{}>,
+): Promise<ResourceOutput[]> {
+  if (bundle.cleanedRequest) {
+    const resource = (
+      await apiCallUrl(z, bundle.cleanedRequest.url, {
+        Accept: "application/vnd.api+json",
+      })
+    ).data as ResourceApiResponse;
+    return [apiResponseToResourceOutput(resource)];
+  }
+  return [];
+}
+
+const trigger: HookTrigger = {
+  key: event,
+  noun: hookLabel,
+  display: {
+    label: hookLabel,
+    description: "Triggers when a resource is created.",
+  },
+  operation: {
+    type: "hook",
+
+    inputFields: [getSubdomainField()],
+
+    performSubscribe: subscribeHookExecute,
+    performUnsubscribe: unsubscribeHookExecute,
+
+    perform: parsePayload,
+    performList: async (
+      z: ZObject,
+      bundle: KontentBundle<SubscribeBundleInputType>,
+    ): Promise<ResourceOutput[]> => {
+      const resources = await listResources(z, bundle);
+      return resources.map(apiResponseToResourceOutput);
+    },
+
+    sample: resourceSample,
+  },
+};
+export default trigger;

--- a/src/triggers/triggerResourceDeleted.ts
+++ b/src/triggers/triggerResourceDeleted.ts
@@ -1,0 +1,71 @@
+import { ZObject } from "zapier-platform-core";
+import { KontentBundle } from "../types/kontentBundle";
+import { listResources, subscribeHook, unsubscribeHook } from "../utils/api";
+import { SubscribeBundleInputType } from "../types/subscribeType";
+import { getSubdomainField } from "../fields/getSudomainsField";
+import { resourceDeletedSample } from "../utils/samples";
+import { ResourceDeletedOutput } from "../types/outputs";
+import { HookTrigger } from "../types/trigger";
+
+const hookLabel = "Resource Deleted";
+const event = "deleted_resource";
+
+async function subscribeHookExecute(
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+) {
+  return subscribeHook(z, bundle, {
+    event,
+    callback_url: bundle.targetUrl ?? "",
+  });
+}
+
+async function unsubscribeHookExecute(
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+) {
+  const webhook = bundle.subscribeData;
+  return unsubscribeHook(z, bundle, webhook?.id ?? "");
+}
+
+async function parsePayload(
+  _z: ZObject,
+  bundle: KontentBundle<{}>,
+): Promise<ResourceDeletedOutput[]> {
+  if (bundle.cleanedRequest?.url) {
+    const id = bundle.cleanedRequest.url.split("/").pop();
+    if (id) {
+      return [{ id }];
+    }
+  }
+  return [];
+}
+
+const trigger: HookTrigger = {
+  key: event,
+  noun: hookLabel,
+  display: {
+    label: hookLabel,
+    description: "Triggers when a resource is deleted.",
+  },
+  operation: {
+    type: "hook",
+
+    inputFields: [getSubdomainField()],
+
+    performSubscribe: subscribeHookExecute,
+    performUnsubscribe: unsubscribeHookExecute,
+
+    perform: parsePayload,
+    performList: async (
+      z: ZObject,
+      bundle: KontentBundle<SubscribeBundleInputType>,
+    ): Promise<ResourceDeletedOutput[]> => {
+      const resources = await listResources(z, bundle);
+      return resources.map((resource) => ({ id: resource.id }));
+    },
+
+    sample: resourceDeletedSample,
+  },
+};
+export default trigger;

--- a/src/triggers/triggerResourceUpdated.ts
+++ b/src/triggers/triggerResourceUpdated.ts
@@ -1,0 +1,80 @@
+import { ZObject } from "zapier-platform-core";
+import { KontentBundle } from "../types/kontentBundle";
+import {
+  apiCallUrl,
+  listResources,
+  subscribeHook,
+  unsubscribeHook,
+} from "../utils/api";
+import { SubscribeBundleInputType } from "../types/subscribeType";
+import { getSubdomainField } from "../fields/getSudomainsField";
+import { resourceSample } from "../utils/samples";
+import { ResourceOutput } from "../types/outputs";
+import { ResourceApiResponse } from "../types/api-responses";
+import { apiResponseToResourceOutput } from "../utils/api-to-output";
+import { HookTrigger } from "../types/trigger";
+
+const hookLabel = "Resource Updated";
+const event = "updated_resource";
+
+async function subscribeHookExecute(
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+) {
+  return subscribeHook(z, bundle, {
+    event,
+    callback_url: bundle.targetUrl ?? "",
+  });
+}
+
+async function unsubscribeHookExecute(
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+) {
+  const webhook = bundle.subscribeData;
+  return unsubscribeHook(z, bundle, webhook?.id ?? "");
+}
+
+async function parsePayload(
+  z: ZObject,
+  bundle: KontentBundle<{}>,
+): Promise<ResourceOutput[]> {
+  if (bundle.cleanedRequest) {
+    const resource = (
+      await apiCallUrl(z, bundle.cleanedRequest.url, {
+        Accept: "application/vnd.api+json",
+      })
+    ).data as ResourceApiResponse;
+    return [apiResponseToResourceOutput(resource)];
+  }
+  return [];
+}
+
+const trigger: HookTrigger = {
+  key: event,
+  noun: hookLabel,
+  display: {
+    label: hookLabel,
+    description: "Triggers when a resource is updated.",
+  },
+  operation: {
+    type: "hook",
+
+    inputFields: [getSubdomainField()],
+
+    performSubscribe: subscribeHookExecute,
+    performUnsubscribe: unsubscribeHookExecute,
+
+    perform: parsePayload,
+    performList: async (
+      z: ZObject,
+      bundle: KontentBundle<SubscribeBundleInputType>,
+    ): Promise<ResourceOutput[]> => {
+      const resources = await listResources(z, bundle);
+      return resources.map(apiResponseToResourceOutput);
+    },
+
+    sample: resourceSample,
+  },
+};
+export default trigger;

--- a/src/types/api-responses.d.ts
+++ b/src/types/api-responses.d.ts
@@ -168,7 +168,25 @@ export type ContactApiResponse = {
   data: { id: string; attributes: { email: string; address: Address } };
 };
 
-type ResourceApiResponse = { id: string; attributes: { name: string } };
+export type ResourceApiResponse = {
+  id: string;
+  attributes: {
+    name: string;
+    resourceType?: "room" | "desk" | "other" | null;
+    usage?: "bookable" | "allocatable";
+    description?: string | null;
+    capacity?: number | null;
+    units?: number;
+    hidden?: boolean;
+    color?: string | null;
+    accountingCode?: string | null;
+    pricing?: {
+      currency: string;
+      pricePerHour: Amount;
+    };
+    photo?: Photo | null;
+  };
+};
 
 type UserApiResponse = {
   included: { id: string; attributes: { subdomain: string } }[];

--- a/src/types/api-responses.d.ts
+++ b/src/types/api-responses.d.ts
@@ -180,10 +180,6 @@ export type ResourceApiResponse = {
     hidden?: boolean;
     color?: string | null;
     accountingCode?: string | null;
-    pricing?: {
-      currency: string;
-      pricePerHour: Amount;
-    };
     photo?: Photo | null;
   };
 };

--- a/src/types/outputs.d.ts
+++ b/src/types/outputs.d.ts
@@ -152,9 +152,6 @@ export type ResourceOutput = {
   hidden: boolean | null;
   color: string | null;
   accountingCode: string | null;
-  pricePerHourNet: string | null;
-  pricePerHourGross: string | null;
-  currency: string | null;
   photoUrl: string | null;
 };
 

--- a/src/types/outputs.d.ts
+++ b/src/types/outputs.d.ts
@@ -140,3 +140,24 @@ export type DropInPassOutput = {
     fullAddress: string | null;
   };
 };
+
+export type ResourceOutput = {
+  id: string;
+  name: string;
+  resourceType: "room" | "desk" | "other" | null;
+  usage: "bookable" | "allocatable" | null;
+  description: string | null;
+  capacity: number | null;
+  units: number | null;
+  hidden: boolean | null;
+  color: string | null;
+  accountingCode: string | null;
+  pricePerHourNet: string | null;
+  pricePerHourGross: string | null;
+  currency: string | null;
+  photoUrl: string | null;
+};
+
+export type ResourceDeletedOutput = {
+  id: string;
+};

--- a/src/types/subscribeType.ts
+++ b/src/types/subscribeType.ts
@@ -1,8 +1,10 @@
 export type SubscribePayloadType = Readonly<{
   event: string;
   callback_url: string;
+  notify_existing?: boolean;
 }>;
 
 export type SubscribeBundleInputType = Readonly<{
   subdomain: string;
+  trigger_for_existing?: boolean;
 }>;

--- a/src/types/subscribeType.ts
+++ b/src/types/subscribeType.ts
@@ -6,5 +6,5 @@ export type SubscribePayloadType = Readonly<{
 
 export type SubscribeBundleInputType = Readonly<{
   subdomain: string;
-  trigger_for_existing?: boolean;
+  trigger_for_existing?: string;
 }>;

--- a/src/utils/api-to-output.ts
+++ b/src/utils/api-to-output.ts
@@ -230,9 +230,6 @@ export function apiResponseToResourceOutput(
     hidden: attrs.hidden ?? null,
     color: attrs.color ?? null,
     accountingCode: attrs.accountingCode ?? null,
-    pricePerHourNet: attrs.pricing?.pricePerHour.net ?? null,
-    pricePerHourGross: attrs.pricing?.pricePerHour.gross ?? null,
-    currency: attrs.pricing?.currency ?? null,
     photoUrl: attrs.photo?.default.url ?? null,
   };
 }

--- a/src/utils/api-to-output.ts
+++ b/src/utils/api-to-output.ts
@@ -14,6 +14,7 @@ import {
   MembershipOutput,
   InvoiceOutput,
   DropInPassOutput,
+  ResourceOutput,
 } from "../types/outputs";
 import { ZObject } from "zapier-platform-core";
 import { at, get } from "lodash";
@@ -211,5 +212,27 @@ export function apiResponseToDropInPassOutput(
     netPrice,
     comments: attrs.comments,
     billingAddress: attrs.billingAddress,
+  };
+}
+
+export function apiResponseToResourceOutput(
+  resource: ResourceApiResponse,
+): ResourceOutput {
+  const attrs = resource.attributes;
+  return {
+    id: resource.id,
+    name: attrs.name,
+    resourceType: attrs.resourceType ?? null,
+    usage: attrs.usage ?? null,
+    description: attrs.description ?? null,
+    capacity: attrs.capacity ?? null,
+    units: attrs.units ?? null,
+    hidden: attrs.hidden ?? null,
+    color: attrs.color ?? null,
+    accountingCode: attrs.accountingCode ?? null,
+    pricePerHourNet: attrs.pricing?.pricePerHour.net ?? null,
+    pricePerHourGross: attrs.pricing?.pricePerHour.gross ?? null,
+    currency: attrs.pricing?.currency ?? null,
+    photoUrl: attrs.photo?.default.url ?? null,
   };
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -430,3 +430,23 @@ export const listRecentDropInPasses = async (
   });
   return response.data.data as DropInPassApiResponse[];
 };
+
+export const listResources = async (
+  z: ZObject,
+  bundle: KontentBundle<SubscribeBundleInputType>,
+): Promise<ResourceApiResponse[]> => {
+  const subdomain = bundle.inputData.subdomain;
+  const space = await spaceForSubdomain(z, subdomain);
+  if (!space) return [];
+  const response = await z.request({
+    url: `https://api.cobot.me/spaces/${space.id}/resources`,
+    method: "GET",
+    headers: {
+      Accept: "application/vnd.api+json",
+    },
+    params: {
+      "filter[usage]": "all",
+    },
+  });
+  return response.data.data as ResourceApiResponse[];
+};

--- a/src/utils/samples.ts
+++ b/src/utils/samples.ts
@@ -5,6 +5,8 @@ import {
   MembershipOutput,
   InvoiceOutput,
   DropInPassOutput,
+  ResourceOutput,
+  ResourceDeletedOutput,
 } from "../types/outputs";
 
 export const bookingSample: BookingOutput = {
@@ -165,4 +167,26 @@ export const dropInPassSample: DropInPassOutput = {
     company: "Acme Inc.",
     fullAddress: "2 Coworking Road",
   },
+};
+
+export const resourceSample: ResourceOutput = {
+  id: "a4a99a71ac8df98d29de357180d273d3",
+  name: "Meeting Room",
+  resourceType: "room",
+  usage: "bookable",
+  description: "Large room, fits 12.",
+  capacity: 12,
+  units: 2,
+  hidden: false,
+  color: "#ff0000",
+  accountingCode: "ROOM",
+  pricePerHourNet: "10.0",
+  pricePerHourGross: "12.0",
+  currency: "EUR",
+  photoUrl:
+    "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
+};
+
+export const resourceDeletedSample: ResourceDeletedOutput = {
+  id: "a4a99a71ac8df98d29de357180d273d3",
 };

--- a/src/utils/samples.ts
+++ b/src/utils/samples.ts
@@ -180,9 +180,6 @@ export const resourceSample: ResourceOutput = {
   hidden: false,
   color: "#ff0000",
   accountingCode: "ROOM",
-  pricePerHourNet: "10.0",
-  pricePerHourGross: "12.0",
-  currency: "EUR",
   photoUrl:
     "https://cdn.com/resource/photo/a4a99a71ac8df98d29de357180d273d3/default_photo.png",
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Zapier hook triggers for Cobot’s `created_resource`, `updated_resource`, and `deleted_resource` webhooks.

### Behavior
- **Created / Updated:** On webhook, fetch the resource from the callback URL via API2 `GET /resources/{id}` (`get-resource`) and map attributes to Zapier output fields.
- **Deleted:** Do not fetch (resource is gone). Return only `{ id }` parsed from the webhook URL.
- **performList:** Lists space resources via `GET /spaces/{id}/resources?filter[usage]=all` for Zap testing (deleted lists ids only).
- **Trigger for existing** (created only): Yes/No string input (default `No`). When `Yes`, subscription creation includes `notify_existing: true` so Cobot immediately sends `created_resource` for each existing resource.

### Output fields (created/updated)
`id`, `name`, `resourceType`, `usage`, `description`, `capacity`, `units`, `hidden`, `color`, `accountingCode`, `photoUrl`

### Tests
Covers subscribe (including `notify_existing`), perform, and performList for each trigger.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcd18-3a98-7ddf-b389-e64557aacdcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcd18-3a98-7ddf-b389-e64557aacdcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

